### PR TITLE
MISP Docker container with on an updated Ubuntu 16.04.02 LTS, MariaDB 10, PHP7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,7 @@
 # # docker build -t <tag> --build-arg MYSQL_ROOT_PASSWORD=<mysql_root_pw> .
 
 # We are based on Ubuntu:trusty
-FROM ubuntu:trusty
-MAINTAINER Xavier Mertens <xavier@rootshell.be>
+FROM ubuntu:xenial
 
 # Set environment variables
 ENV DEBIAN_FRONTEND noninteractive
@@ -22,7 +21,7 @@ RUN echo "DEBUG"
 # Upgrade Ubuntu
 RUN \
   apt-get update && \
-  apt-get dist-upgrade -y && \
+#  apt-get dist-upgrade -y && \
   apt-get autoremove -y && \
   apt-get clean
 
@@ -39,15 +38,15 @@ RUN \
 ADD supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 
 # Preconfigure setting for packages
-RUN echo "mysql-server mysql-server/root_password password $MYSQL_ROOT_PASSWORD" | debconf-set-selections
-RUN echo "mysql-server mysql-server/root_password_again password $MYSQL_ROOT_PASSWORD" | debconf-set-selections
+RUN echo "mariadb-server-10.0 mysql-server/root_password password $MYSQL_ROOT_PASSWORD" | debconf-set-selections
+RUN echo "mariadb-server-10.0 mysql-server/root_password_again password $MYSQL_ROOT_PASSWORD" | debconf-set-selections
 #RUN echo "postfix postfix/main_mailer_type string Local only" | debconf-set-selections 
 #RUN echo "postfix postfix/mailname string localhost.localdomain" | debconf-set-selections
 
 # Install packages
 RUN \ 
-  apt-get install -y libjpeg8-dev apache2 curl git less libapache2-mod-php5 make mysql-common-5.6 mysql-client-5.6 mysql-server-5.6 php5-gd \
-                     php5-mysql php5-dev php-pear postfix redis-server sudo tree vim zip openssl gnupg gnupg-agent  \
+  apt-get install -y libjpeg8-dev apache2 curl git less libapache2-mod-php make mariadb-server mariadb-client  php-gd \
+                     php-mysql php-dev php-pear postfix redis-server sudo tree vim zip openssl gnupg gnupg-agent  \
                      whois && \
   apt-get clean
 
@@ -107,12 +106,12 @@ RUN \
 
 # CakeResque normally uses phpredis to connect to redis, but it has a (buggy) fallback connector through Redisent. 
 # It is highly advised to install phpredis
-RUN pecl install redis-2.2.8
-RUN apt-get install -y php5-redis
+RUN pecl install redis-3.1.1
+RUN apt-get install -y php-redis
 
 # After installing it, enable it in your php.ini file
 # add the following line
-RUN echo "extension=redis.so" >> /etc/php5/apache2/php.ini
+RUN echo "extension=redis.so" >> /etc/php/7.0/apache2/php.ini
 
 # To use the scheduler worker for scheduled tasks, do the following
 RUN cp -fa /var/www/MISP/INSTALL/setup/config.php /var/www/MISP/app/Plugin/CakeResque/Config/config.php

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,7 @@ RUN echo "mariadb-server-10.0 mysql-server/root_password_again password $MYSQL_R
 # Install packages
 RUN \ 
   apt-get install -y libjpeg8-dev apache2 curl git less libapache2-mod-php make mariadb-server mariadb-client  php-gd \
-                     php-mysql php-dev php-pear postfix redis-server sudo tree vim zip openssl gnupg gnupg-agent  \
+                     php-mysql php-dev php7.0-mbstring php-pear postfix redis-server sudo tree vim zip openssl gnupg gnupg-agent  \
                      whois && \
   apt-get clean
 

--- a/run.sh
+++ b/run.sh
@@ -29,7 +29,7 @@ if [ -r /.firstboot.tmp ]; then
 	service mysql start >/dev/null 2>&1
 	sleep 5
 
-	ret=`echo 'SHOW DATABASES;' | mysql -u root --password="$MYSQL_ROOT_PASSWORD" -h 127.0.0.1 -P 3306 # 2>&1`
+	ret=`echo 'SHOW DATABASES;' | mysql -u root # 2>&1`
 
 	if [ $? -eq 0 ]; then
 		echo "Connected to database successfully!"
@@ -48,12 +48,12 @@ create database misp;
 grant usage on *.* to misp identified by "$MYSQL_MISP_PASSWORD";
 grant all privileges on misp.* to misp;
 EOSQL
-			ret=`mysql -u root --password="$MYSQL_ROOT_PASSWORD" -h 127.0.0.1 -P 3306 2>&1 < /tmp/create_misp_database.sql`
+			ret=`mysql -u root  2>&1 < /tmp/create_misp_database.sql`
 			if [ $? -eq 0 ]; then
 				echo "Created database misp successfully!"
 
 				echo "Importing /var/www/MISP/INSTALL/MYSQL.sql ..."
-				ret=`mysql -u misp --password="$MYSQL_MISP_PASSWORD" misp -h 127.0.0.1 -P 3306 2>&1 < /var/www/MISP/INSTALL/MYSQL.sql`
+				ret=`mysql -u misp --password="$MYSQL_MISP_PASSWORD" misp 2>&1 < /var/www/MISP/INSTALL/MYSQL.sql`
 				if [ $? -eq 0 ]; then
 					echo "Imported /var/www/MISP/INSTALL/MYSQL.sql successfully"
 				else
@@ -95,10 +95,10 @@ EOSQL
 
 	# Fix php.ini with recommended settings
 	echo "Optimizing php.ini (based on MISP recommendations) ..."
-	sed -i "s/max_execution_time = 30/max_execution_time = 300/" /etc/php5/apache2/php.ini
-	sed -i "s/memory_limit = 128M/memory_limit = 512M/" /etc/php5/apache2/php.ini
-	sed -i "s/upload_max_filesize = 2M/upload_max_filesize = 50M/" /etc/php5/apache2/php.ini
-	sed -i "s/post_max_size = 8M/post_max_size = 50M/" /etc/php5/apache2/php.ini
+	sed -i "s/max_execution_time = 30/max_execution_time = 300/" /etc/php/7.0/apache2/php.ini
+	sed -i "s/memory_limit = 128M/memory_limit = 512M/" /etc/php/7.0/apache2/php.ini
+	sed -i "s/upload_max_filesize = 2M/upload_max_filesize = 50M/" /etc/php/7.0/apache2/php.ini
+	sed -i "s/post_max_size = 8M/post_max_size = 50M/" /etc/php/7.0/apache2/php.ini
 
 	# Generate the admin user PGP key
 	if [ -z "$MISP_ADMIN_EMAIL" -o -z "$MISP_ADMIN_PASSPHRASE" ]; then


### PR DESCRIPTION
I've updated the Dockerfile and run.sh to run MISP on Ubuntu 16.04.02 LTS, MariaDB 10, and PHP7.